### PR TITLE
Reimplement pot logic in order to fix #31

### DIFF
--- a/poker-core/src/game.rs
+++ b/poker-core/src/game.rs
@@ -17,6 +17,19 @@ pub enum BetAction {
     AllIn(Currency),
 }
 
+impl std::fmt::Display for BetAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            BetAction::Check => write!(f, "Check"),
+            BetAction::Fold => write!(f, "Fold"),
+            BetAction::Call(v) => write!(f, "Call({})", v),
+            BetAction::Bet(v) => write!(f, "Bet({})", v),
+            BetAction::Raise(v) => write!(f, "Raise({})", v),
+            BetAction::AllIn(v) => write!(f, "AllIn({})", v),
+        }
+    }
+}
+
 #[derive(Debug, derive_more::Display)]
 pub enum BetError {
     AllInWithoutBeingAllIn,

--- a/poker-core/src/game/players.rs
+++ b/poker-core/src/game/players.rs
@@ -1,5 +1,4 @@
 use super::{deck::Card, BetAction, BetError, Currency, GameError};
-use serde::{Deserialize, Serialize};
 pub const MAX_PLAYERS: usize = 12;
 
 pub type PlayerId = i32;
@@ -127,12 +126,12 @@ impl SeatedPlayers {
 
     /// The mutable version of `player_by_id`
     pub(crate) fn player_by_id_mut(&mut self, player: PlayerId) -> Option<&mut SeatedPlayer> {
-        self.players_iter_mut().find(|x| x.id == player.into())
+        self.players_iter_mut().find(|x| x.id == player)
     }
 
     /// Gets a reference to the player if their account ID could be found
     pub(crate) fn player_by_id(&self, player: PlayerId) -> Option<&SeatedPlayer> {
-        self.players_iter().find(|x| x.id == player.into())
+        self.players_iter().find(|x| x.id == player)
     }
 
     /// This function is not aware of the current bet. As such validation must be handled before
@@ -147,7 +146,6 @@ impl SeatedPlayers {
         player: PlayerId,
         action: BetAction,
     ) -> Result<PlayerBetAction, BetError> {
-        let player = player.into();
         // Check player is even in the betting
         let p: &mut SeatedPlayer = self
             .player_by_id_mut(player)
@@ -372,7 +370,7 @@ impl SeatedPlayer {
 
     pub(self) fn new<C: Into<Currency>>(id: PlayerId, monies: C, seat_index: usize) -> Self {
         SeatedPlayer {
-            id: id.into(),
+            id,
             pocket: None,
             monies: monies.into(),
             bet_status: BetStatus::Folded,

--- a/poker-core/src/game/pot.rs
+++ b/poker-core/src/game/pot.rs
@@ -579,7 +579,6 @@ mod tests {
         for log_item in &log {
             println!("{}", log_item);
         }
-        assert!(false);
         assert_eq!(payout[&3], 39.into());
         assert_eq!(payout[&2], 16.into());
         // 1 overbet and was returned pot nobody else could claim

--- a/poker-core/src/game/pot.rs
+++ b/poker-core/src/game/pot.rs
@@ -451,6 +451,42 @@ mod tests {
         }
         assert_eq!(side_pot.max_in, Currency::max());
     }
+
+    #[test]
+    fn all_all_in() {
+        let mut p = Pot::default();
+        p.bet(1, BetAction::AllIn(5.into()));
+        p.bet(2, BetAction::AllIn(15.into()));
+        p.bet(3, BetAction::AllIn(45.into()));
+        p.finalize_round();
+        //dbg!(&p);
+        assert_eq!(p.players_in.len(), 3);
+        assert_eq!(*p.max_in, 5);
+        let side_pot = p.side_pot.unwrap();
+        assert_eq!(side_pot.players_in.len(), 2);
+        assert_eq!(*side_pot.max_in, 10);
+        let side_pot = side_pot.side_pot.unwrap();
+        assert_eq!(side_pot.players_in.len(), 1);
+        assert_eq!(*side_pot.max_in, 30);
+
+        let mut p = Pot::default();
+        p.bet(1, BetAction::AllIn(45.into()));
+        p.bet(2, BetAction::AllIn(15.into()));
+        p.bet(3, BetAction::AllIn(5.into()));
+        p.finalize_round();
+        dbg!(&p);
+        assert_eq!(p.players_in.len(), 3);
+        assert_eq!(*p.max_in, 5);
+        let side_pot = p.side_pot.unwrap();
+        assert_eq!(side_pot.players_in.len(), 2);
+        assert_eq!(*side_pot.max_in, 10);
+        let side_pot = side_pot.side_pot.unwrap();
+        assert_eq!(side_pot.players_in.len(), 1);
+        assert_eq!(*side_pot.max_in, 20);
+        let side_pot = side_pot.side_pot.unwrap();
+        assert_eq!(side_pot.players_in.len(), 1);
+        assert_eq!(*side_pot.max_in, 10);
+    }
 }
 
 #[cfg(test)]

--- a/poker-core/src/game/pot.rs
+++ b/poker-core/src/game/pot.rs
@@ -1,7 +1,9 @@
 use super::players::PlayerId;
 use super::BetAction;
 use derive_more::{Add, AddAssign, Div, From, Mul, Rem, Sub, SubAssign, Sum};
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::collections::HashMap;
 
 #[derive(
@@ -42,6 +44,23 @@ impl std::fmt::Display for Currency {
     }
 }
 
+/// Players put Stakes in Pots. Binds an is_allin flag to the bet amount, as an important part of
+/// pot logic is keeping track of AllIn-related limits on winnings.
+#[derive(Debug, Copy, Clone)]
+struct Stake {
+    is_allin: bool,
+    amount: Currency,
+}
+
+impl From<(bool, Currency)> for Stake {
+    fn from(tup: (bool, Currency)) -> Self {
+        Self {
+            is_allin: tup.0,
+            amount: tup.1,
+        }
+    }
+}
+
 /// Divide X as evenly as possible Y ways using only positive ints, and return those ints.
 ///
 /// Consider x=5 and y=3. 5 cannot be divided into 3 pieces evenly using ints. This function would
@@ -73,213 +92,294 @@ fn split_x_by_y(x: i32, y: i32) -> Vec<i32> {
     ret
 }
 
-/// Handles all pot related operations.
-/// Only tracks monies committed to the pot.
-/// As such, does no error handling and cannot fail.
-/// Parent must validate player has enough monies, and track the state of the betting round.
+/// "Public" interface to a pot. Tell the pot when players bet, when betting rounds are over, and
+/// the order of winning hands when it's time to pay out, and Pot will take care of all the dirty
+/// details.
+///
+/// Pot only tracks monitary commitments to the pot. It doesn't do error handling and will
+/// generally never fail. Pot will not check that the bets make sense. If you put garbage in, you
+/// will get garbage out.
+///
+/// Pot ignores folds. When calling the payout function, only provide players that are still in the
+/// hand.
+///
+/// # Usage
+///
+/// ## `bet(...)`
+///
+/// Call this to record every player's bet as they make them. Always use their total commitment in
+/// the current betting round. For example, if a player bets 10, gets raised to 30, then calls the
+/// raise for a total of 30, you are to give Bet(10), Raise(30), Call(30) (with the appropriate
+/// players, of course) as these represent each player's *total* commitment.
+///
+/// ## `finalize_round()`
+///
+/// Call this between betting rounds so the working pot can be settled and future betting can
+/// establish a new pot. This *must* be called before `payout(...)`.
+///
+/// ## `payout(...)`
+///
+/// Immediately after calling `finalize_round()` for the last time, call this to calculate and
+/// return the payouts for each winning player. This consumes the Pot. See the function
+/// documentation for more information.
 #[derive(Debug)]
 pub struct Pot {
-    players_in: HashMap<PlayerId, Currency>,
-    max_in: Currency,
-    side_pot: Option<Box<Pot>>,
-    is_settled: bool,
+    /// Pots from previous betting rounds. These will not be changed, and when it comes time to pay
+    /// the winner, these are where the funds come from.
+    settled: Vec<InnerPot>,
+    /// Cache for storing the players that are participating in the current betting round and their
+    /// bets. When a betting round is finalized, this is emptied, and InnerPot(s) are created and
+    /// added to settled.
+    working: HashMap<PlayerId, Stake>,
 }
 
-impl Pot {
-    /// Returns the total value in this pot
-    /// Not particularily useful due to each betting round spinning off a side pot
-    pub(crate) fn value(&self) -> Currency {
-        self.players_in.values().copied().sum()
-    }
+/// An innner subpot that Pot uses to keep track of pools of money that players can win. New
+/// InnerPots are created every betting round and extra ones are created when players go all in.
+#[derive(Debug)]
+struct InnerPot {
+    /// The players that are eligible to win this pot and the stake they put into this pot
+    /// (is_allin, amount).
+    players: HashMap<PlayerId, Stake>,
+    /// The maximum amount a player entering this pot is allowed to bet. This is only non-None for
+    /// pots containing 1+ player that is all in.
+    max_in: Option<Currency>,
+}
 
-    pub fn total_value(&self) -> Currency {
-        let mut v = self.players_in.values().copied().sum();
-        if let Some(x) = self.side_pot.as_ref() {
-            v += x.total_value();
-        }
-        v
-    }
-
-    fn overflowing_add(&mut self, player: PlayerId, amount: Currency) {
-        if self.is_settled {
-            self.side_pot().overflowing_add(player, amount);
-        } else {
-            let ov = self.players_in.get(&player).copied().unwrap_or_default();
-            let nv = ov + amount;
-            if nv > self.max_in {
-                self.players_in.insert(player, self.max_in);
-                let o = nv - self.max_in;
-                self.side_pot().overflowing_add(player, o);
-            } else {
-                self.players_in.insert(player, nv);
-            }
-        }
-    }
-
-    fn side_pot(&mut self) -> &mut Pot {
-        if self.side_pot.is_none() {
-            self.side_pot = Some(Box::new(Pot::default()));
-        }
-        self.side_pot.as_mut().unwrap()
-    }
-
-    fn update_max(&mut self, new_max: Currency) {
-        use std::cmp::Ordering;
-        if self.is_settled {
-            self.side_pot().update_max(new_max);
-        } else {
-            if new_max == Currency::max() || new_max < 1.into() {
-                return;
-            }
-            match new_max.cmp(&self.max_in) {
-                Ordering::Greater => self.side_pot().update_max(new_max),
-                Ordering::Less => {
-                    let ov = self.max_in;
-                    self.max_in = new_max;
-                    if ov != Currency::max() {
-                        self.side_pot().update_max(ov - new_max);
-                    }
-                }
-                Ordering::Equal => (),
-            }
-        }
-    }
-
-    /// Parent MUST call this in between betting rounds.
-    /// Closes the betting round of all open pots. Next betting roung will create a fresh pot.
-    /// This prevents confusion between max_in and next betting rounds.
-    pub(crate) fn finalize_round(&mut self) {
-        self.is_settled = true;
-        if let Some(x) = self.side_pot.as_mut() {
-            x.finalize_round();
-        }
-    }
-
-    /// Detected a change in max_bet that could have consquences, forcing a rebuild
-    fn overflow(&mut self) {
-        if self.is_settled {
-            self.side_pot().overflow();
-        } else {
-            for (player, value) in self.players_in.clone() {
-                if value > self.max_in {
-                    let delta = value - self.max_in;
-                    self.players_in.insert(player, self.max_in);
-                    self.overflowing_add(player, delta);
-                }
-            }
-        }
-    }
-
-    /// Takes a vector of player Ids and returns the count of them that are in the current pot
-    fn num_players_in(&self, hand: &[PlayerId]) -> usize {
-        let mut r = 0;
-        for i in hand {
-            if self.players_in.contains_key(i) {
-                r += 1;
-            }
-        }
-        r
-    }
-
-    /// Consumes the pot and returns the total payout.
+impl InnerPot {
+    /// For this InnerPot only, return the player(s) that won and the amount they won.
     ///
-    /// # Panics
-    ///
-    /// Panics if the pot would pay out a different amount than is in the pot.
-    /// This indicates a failure of the payout function and should be investigated.
-    pub(crate) fn payout(self, ranked_hands: &[Vec<PlayerId>]) -> HashMap<PlayerId, Currency> {
+    /// See Pot's payout function for more information on the ranked_players argument.
+    fn payout(self, ranked_players: &[Vec<PlayerId>]) -> HashMap<PlayerId, Currency> {
         let mut hm: HashMap<PlayerId, Currency> = HashMap::new();
-        let value = self.value();
-        for best_hand in ranked_hands {
-            let hands_in = self.num_players_in(best_hand);
-            // Prevents divide by zero below
-            if hands_in == 0 {
+        // Loop over the player rank groups. The first group that contains >0 players in this pot is
+        // used, and then we are done. So we generally expect to only loop once. Remember, the
+        // player(s) with the best hand are in the first group.
+        for player_group in ranked_players {
+            // See if any of the players in this group were eligible to win this pot. If not, move
+            // on to the next group
+            let winning_players: Vec<_> = player_group
+                .iter()
+                .filter(|&&p| self.players.contains_key(&p))
+                .collect();
+            if winning_players.is_empty() {
                 continue;
             }
-            let players = best_hand
-                .iter()
-                .filter(|p| self.players_in.contains_key(p))
-                .collect::<Vec<_>>();
-            assert!(!players.is_empty());
-            let payouts = split_x_by_y(*value, players.len().try_into().unwrap());
-            assert_eq!(players.len(), payouts.len());
-            for (player, payout) in itertools::zip(players, payouts) {
+            assert!(!winning_players.is_empty());
+            // split the payout evenly across all the winning players. It's important that we
+            // avoided division by 0 by making sure there is >0 winning players.
+            let payouts = split_x_by_y(*self.value(), winning_players.len().try_into().unwrap());
+            for (player, payout) in itertools::zip(winning_players, payouts) {
                 hm.insert(*player, payout.into());
             }
             break;
         }
-        assert_eq!(hm.values().copied().sum::<Currency>(), self.value());
-        if let Some(x) = self.side_pot {
-            crate::util::merge_hashmap(&mut hm, x.payout(ranked_hands));
+        hm
+    }
+
+    /// Returns the sum of all the bets all players in this pot have made.
+    fn value(&self) -> Currency {
+        self.players.values().copied().map(|s| s.amount).sum()
+    }
+}
+
+impl Pot {
+    /// Call this function between rounds to mark the betting round as over.
+    ///
+    /// The cache of players and their bets is turned into one or more InnerPots, which are then
+    /// stored in our settled vec of InnerPots (at which point they won't be touched). Side pots are
+    /// automatically created if 1+ players have gone all in.
+    pub(crate) fn finalize_round(&mut self) {
+        // The new pot(s) we will add to our vec of settled pots
+        let mut pots: Vec<InnerPot> = vec![];
+        // Sort the players that are in this betting round such that:
+        // - players that went all in are first, and
+        // - a player that are all in for less than another all in player comes first.
+        let iter = self.working.drain().sorted_unstable_by(|l, r| {
+            match (l.1.is_allin, r.1.is_allin) {
+                // both all in, and smallest amount should be first.
+                (true, true) => l.1.amount.cmp(&r.1.amount),
+                // left all in, so must be less than (before) right
+                (true, false) => Ordering::Less,
+                // right all in, so must be less than left
+                (false, true) => Ordering::Greater,
+                // neither all in, so equal
+                (false, false) => Ordering::Equal,
+            }
+        });
+        // for each player, add their stake to the pots, possibly splitting it up across pots if
+        // necessary due to other players going all in.
+        for (player, mut stake) in iter {
+            for pot in &mut pots {
+                match pot.max_in {
+                    // This pot doesn't have an existing all in player, so this player can add an
+                    // unlimted amount to it. (In practice, assuming no all ins, the caller should
+                    // be verifying that all players are in for the same amount, so "unlimted"
+                    // really means "the same exact amount as everyone else").
+                    None => {
+                        pot.players.insert(player, stake);
+                        // Reduce the amount to 0, indicating to future code that the player's bet
+                        // is fully accounted for.
+                        stake.amount = 0.into();
+                        // and since there is no more amount to add to inner pots, stop iterating
+                        // over the inner pots.
+                        break;
+                    }
+                    // THere is an all in player in this pot, so there is a limit on how much this
+                    // player can add to it.
+                    Some(max_in) => match stake.amount.cmp(&max_in) {
+                        // If this player is adding less or equal than the existing limit, then
+                        // simply add them to the pot and be done. (In practice, we expect them to
+                        // be adding equal as they have called an all in).
+                        Ordering::Less | Ordering::Equal => {
+                            pot.players.insert(player, stake);
+                            // Indicate the bet is fully accounted for.
+                            stake.amount = 0.into();
+                            // Stop interating over the pots since no more amount to add to pots.
+                            break;
+                        }
+                        // The player wants to add more than the limit, so add the limit for them
+                        // and reduce their stake that shall be put into the next pot(s)
+                        Ordering::Greater => {
+                            pot.players.insert(player, (stake.is_allin, max_in).into());
+                            stake.amount -= max_in;
+                        }
+                    },
+                }
+            }
+            // The player's bet has not been fully accounted for in the existing inner pots. An
+            // example of when this would happen is: this is the second player to go all in this
+            // betting round, and they've done so for more than the first player. We create a new
+            // inner pot for them and add it to the list of pots. Future iterations of this loop
+            // with the next players and their bets will add to this pot.
+            if stake.amount > 0.into() {
+                let mut new = InnerPot {
+                    max_in: match stake.is_allin {
+                        false => None,
+                        true => Some(stake.amount),
+                    },
+                    ..Default::default()
+                };
+                new.players.insert(player, stake);
+                pots.push(new);
+            }
+        }
+        // Finally done creating all the new pots, so move them to settled.
+        self.settled.append(&mut pots);
+    }
+
+    #[cfg(test)]
+    fn settled_value(&self) -> Currency {
+        let mut ret = 0.into();
+        for sp in &self.settled {
+            ret += sp.players.values().copied().map(|s| s.amount).sum();
+        }
+        ret
+    }
+
+    /// Consumes the pot and returns the total payout.
+    ///
+    /// The argument is a vec of the player's hand rankings relative to each other.
+    /// The first item in the vec is another vec, and this inner vec is the players that have
+    /// equally good and the best hands. The second item is a vec for runner up players, etc.
+    ///
+    /// For example, passing [[1], [2], [3]] means player 1 had the best hand, followed by 2, and 3
+    /// had the worst.
+    ///
+    /// Passing [[1, 2], [3]] means player 1 and 2 had the best hands and they are equal. 3 had the worst.
+    ///
+    /// **Only provide players that are still eligible to win (part of) the pot**. Do not include
+    /// players that have folded. The reason for including more than just the best player(s) is to
+    /// be able to handle side pots. This is also why this function returns a HashMap of players
+    /// and their respective winnings.
+    ///
+    /// # Returns
+    ///
+    /// HashMap of players and the amount they should be awared from the pot(s).
+    pub(crate) fn payout<P: Into<PlayerId> + Copy>(
+        mut self,
+        ranked_players: &[Vec<P>],
+    ) -> HashMap<PlayerId, Currency> {
+        // In case caller didn't call finalize_round() after the last betting round, do it for them.
+        if !self.working.is_empty() {
+            self.finalize_round();
+        }
+        assert!(self.working.is_empty());
+
+        // The items are Into<PlayerId> ... this gets PlayerIds.
+        let ranked_players: Vec<Vec<PlayerId>> = ranked_players
+            .iter()
+            .map(|list| list.iter().map(|&p| p.into()).collect())
+            .collect();
+        let mut hm: HashMap<PlayerId, Currency> = HashMap::new();
+        // Ha! Made you look. All the hard work is done in each inner pot, and the results simply
+        // merged together here.
+        for pot in self.settled {
+            crate::util::merge_hashmap(&mut hm, pot.payout(&ranked_players));
         }
         hm
     }
 
-    /// Takes the players TOTAL bet. I.e. Bet(10), Call(20) = bet of 20.
-    /// As such, parent must track the current betting round.
-    pub(crate) fn bet<A: Into<PlayerId>>(&mut self, player: A, action: BetAction) -> Currency {
-        use std::cmp::Ordering;
+    /// Record that a player has made a bet. The player's **total** bet is to be provided. I.e. if
+    /// in a single betting round a player Bet(10) and then Call(30) (due to another player
+    /// raising), give this function Call(30), not Call(20).
+    pub(crate) fn bet<A: Into<PlayerId>>(&mut self, player: A, action: BetAction) {
         let player = player.into();
-        if self.is_settled {
-            self.side_pot().bet(player, action)
-        } else {
-            let ov = self.players_in.get(&player).copied().unwrap_or_default();
-            let value = match action {
-                BetAction::AllIn(v) => match v.cmp(&self.max_in) {
-                    Ordering::Greater => {
-                        let nv = v - self.max_in - ov;
-                        self.players_in.insert(player, self.max_in);
-                        self.side_pot().bet(player, BetAction::AllIn(nv))
-                    }
-                    Ordering::Equal => v,
-                    Ordering::Less => {
-                        self.update_max(v);
-                        self.overflow();
-                        v
-                    }
-                },
-                BetAction::Bet(v) | BetAction::Call(v) | BetAction::Raise(v) => v,
-                // Folds and checks have no effect on the pot.
-                BetAction::Fold | BetAction::Check => return 0.into(),
-            };
-            self.overflowing_add(player, value - ov);
-            0.into()
+        let stake: Stake = match action {
+            BetAction::Check | BetAction::Fold => {
+                return;
+            }
+            BetAction::Call(v) | BetAction::Bet(v) | BetAction::Raise(v) => (false, v),
+            BetAction::AllIn(v) => (true, v),
         }
+        .into();
+        self.working.insert(player, stake);
     }
 }
 
 impl Default for Pot {
     fn default() -> Self {
         Pot {
-            players_in: HashMap::new(),
-            max_in: Currency::max(),
-            side_pot: None,
-            is_settled: false,
+            // With no all ins and going all the way to showdown, 3 is the expected number.
+            // It's not a big deal if this isn't perfectly accurate. It's just a guess to usually
+            // avoid reallocation. It can/will be more if people go all in.
+            settled: Vec::with_capacity(3),
+            working: HashMap::default(),
+        }
+    }
+}
+
+impl Default for InnerPot {
+    fn default() -> Self {
+        Self {
+            players: HashMap::new(),
+            max_in: None,
         }
     }
 }
 
 #[cfg(test)]
-mod tests {
+mod test_payout {
     use super::*;
 
     #[test]
-    fn basic_pot() {
+    fn simple_single_winner() {
         let mut p = Pot::default();
         p.bet(1, BetAction::Bet(5.into()));
         p.bet(2, BetAction::Call(5.into()));
         p.bet(3, BetAction::Call(5.into()));
-        let payout = p.payout(&vec![vec![1.into()]]);
+        p.finalize_round();
+        let payout = p.payout(&vec![vec![1]]);
         assert_eq!(payout[&1.into()], 15.into());
     }
 
     #[test]
-    fn multi_winners() {
+    fn simple_multi_winner() {
         let mut p = Pot::default();
         p.bet(1, BetAction::Bet(5.into()));
-        p.bet(2, BetAction::Bet(5.into()));
-        p.bet(3, BetAction::Bet(5.into()));
-        let payout = p.payout(&vec![vec![1.into(), 2.into()]]);
+        p.bet(2, BetAction::Call(5.into()));
+        p.bet(3, BetAction::Call(5.into()));
+        p.finalize_round();
+        let payout = p.payout(&vec![vec![1, 2]]);
         assert_eq!(payout[&1.into()], 8.into());
         assert_eq!(payout[&2.into()], 7.into());
 
@@ -290,7 +390,8 @@ mod tests {
         p.bet(1, BetAction::Bet(5.into()));
         p.bet(2, BetAction::Bet(5.into()));
         p.bet(3, BetAction::Bet(6.into()));
-        let payout = p.payout(&vec![vec![1.into(), 2.into()]]);
+        p.finalize_round();
+        let payout = p.payout(&vec![vec![1, 2]]);
         assert_eq!(payout[&1.into()], 8.into());
         assert_eq!(payout[&2.into()], 8.into());
     }
@@ -301,12 +402,18 @@ mod tests {
         p.bet(1, BetAction::Bet(5.into()));
         p.bet(2, BetAction::Bet(5.into()));
         p.bet(3, BetAction::Bet(5.into()));
-        let payout = p.payout(&vec![vec![1.into(), 2.into(), 3.into()]]);
+        p.finalize_round();
+        let payout = p.payout(&vec![vec![1, 2, 3]]);
         dbg!(&payout);
         assert_eq!(payout[&1.into()], 5.into());
         assert_eq!(payout[&2.into()], 5.into());
         assert_eq!(payout[&3.into()], 5.into());
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
 
     #[test]
     fn all_in_blind() {
@@ -314,10 +421,17 @@ mod tests {
         p.bet(1, BetAction::AllIn(5.into()));
         p.bet(2, BetAction::Bet(10.into()));
         p.bet(3, BetAction::AllIn(8.into()));
+        p.finalize_round();
         dbg!(&p);
-        let payout = p.payout(&vec![vec![1.into()], vec![2.into(), 3.into()]]);
+        let payout = p.payout(&vec![vec![1], vec![2, 3]]);
         dbg!(&payout);
+        // 5 from each player, 8 remains (5 from p2's call and 3 from p3's allin)
         assert_eq!(payout[&1.into()], 15.into());
+        // a second side pot containing 6 (3 for p3's all in, and 3 from p2's call) exists. p2 and
+        // p3 tied, so they split it.
+        // p2 has 3 and p3 has 3.
+        // The final pot has just p2 and their remaining 2. They get that whole pot.
+        // p2 has 3+2 and p3 has 3 still.
         assert_eq!(payout[&2.into()], 5.into());
         assert_eq!(payout[&3.into()], 3.into());
     }
@@ -328,7 +442,9 @@ mod tests {
         p.bet(1, BetAction::Bet(10.into()));
         p.bet(2, BetAction::AllIn(5.into()));
         p.bet(3, BetAction::Bet(10.into()));
-        let payout = p.payout(&vec![vec![2.into()], vec![1.into(), 3.into()]]);
+        p.finalize_round();
+        dbg!(&p);
+        let payout = p.payout(&vec![vec![2], vec![1, 3]]);
         assert_eq!(payout[&2.into()], 15.into());
         assert_eq!(payout[&1.into()], 5.into());
         assert_eq!(payout[&3.into()], 5.into());
@@ -340,8 +456,9 @@ mod tests {
         p.bet(1, BetAction::Bet(10.into()));
         p.bet(2, BetAction::AllIn(5.into()));
         p.bet(3, BetAction::AllIn(3.into()));
+        p.finalize_round();
         dbg!(&p);
-        let payout = p.payout(&vec![vec![3.into()], vec![2.into()], vec![1.into()]]);
+        let payout = p.payout(&vec![vec![3], vec![2], vec![1]]);
         dbg!(&payout);
         assert_eq!(payout[&3.into()], 9.into());
         assert_eq!(payout[&2.into()], 4.into());
@@ -368,7 +485,7 @@ mod tests {
         p.finalize_round();
         // 43 + 6,6 + 4 = 59 in pot
         dbg!(&p);
-        let payout = p.payout(&vec![vec![3.into()], vec![2.into()], vec![1.into()]]);
+        let payout = p.payout(&vec![vec![3], vec![2], vec![1]]);
         dbg!(&payout);
         assert_eq!(payout[&3.into()], 39.into());
         assert_eq!(payout[&2.into()], 16.into());
@@ -380,14 +497,15 @@ mod tests {
     /// bet, call, and raise are all semantically the same as far as the pot is concerned.
     fn bet_call_raise() {
         fn helper(p: Pot) {
-            assert_eq!(p.players_in.len(), 3);
-            for v in p.players_in.values() {
-                assert_eq!(*v, 5.into());
+            assert_eq!(p.settled.len(), 1);
+            let ip = &p.settled[0];
+            assert_eq!(ip.players.len(), 3);
+            for v in ip.players.values() {
+                assert_eq!(v.amount, 5.into());
             }
-            assert_eq!(p.max_in, Currency::max());
-            assert!(p.side_pot.is_none());
+            assert_eq!(ip.max_in, None);
             dbg!(&p);
-            let payout = p.payout(&vec![vec![1.into()]]);
+            let payout = p.payout(&vec![vec![1]]);
             assert_eq!(payout[&(1.into())], 15.into());
             dbg!(&payout);
         }
@@ -420,7 +538,7 @@ mod tests {
         p.bet(1, BetAction::Call(15.into()));
         p.bet(2, BetAction::Call(15.into()));
         p.finalize_round();
-        assert_eq!(p.total_value(), 45.into());
+        assert_eq!(p.settled_value(), 45.into());
         p.bet(1, BetAction::Bet(5.into()));
         p.bet(2, BetAction::AllIn(50.into()));
         p.bet(3, BetAction::Call(50.into()));
@@ -431,25 +549,28 @@ mod tests {
         // lets pretend that's the end and make sure the pots are exactly as expected
         dbg!(&p);
 
-        assert_eq!(p.players_in.len(), 3);
-        for v in p.players_in.values() {
-            assert_eq!(*v, 15.into());
-        }
-        assert_eq!(p.max_in, Currency::max());
+        assert_eq!(p.settled.len(), 3);
 
-        let side_pot = p.side_pot.unwrap();
-        assert_eq!(side_pot.players_in.len(), 3);
-        for v in side_pot.players_in.values() {
-            assert_eq!(*v, 50.into());
+        let pot = &p.settled[0];
+        assert_eq!(pot.players.len(), 3);
+        for v in pot.players.values() {
+            assert_eq!(v.amount, 15.into());
         }
-        assert_eq!(side_pot.max_in, 50.into());
+        assert_eq!(pot.max_in, None);
 
-        let side_pot = side_pot.side_pot.unwrap();
-        assert_eq!(side_pot.players_in.len(), 1);
-        for v in side_pot.players_in.values() {
-            assert_eq!(*v, 450.into());
+        let pot = &p.settled[1];
+        assert_eq!(pot.players.len(), 3);
+        for v in pot.players.values() {
+            assert_eq!(v.amount, 50.into());
         }
-        assert_eq!(side_pot.max_in, Currency::max());
+        assert_eq!(pot.max_in, Some(50.into()));
+
+        let pot = &p.settled[2];
+        assert_eq!(pot.players.len(), 1);
+        for v in pot.players.values() {
+            assert_eq!(v.amount, 450.into());
+        }
+        assert_eq!(pot.max_in, None);
     }
 
     #[test]
@@ -459,15 +580,18 @@ mod tests {
         p.bet(2, BetAction::AllIn(15.into()));
         p.bet(3, BetAction::AllIn(45.into()));
         p.finalize_round();
-        //dbg!(&p);
-        assert_eq!(p.players_in.len(), 3);
-        assert_eq!(*p.max_in, 5);
-        let side_pot = p.side_pot.unwrap();
-        assert_eq!(side_pot.players_in.len(), 2);
-        assert_eq!(*side_pot.max_in, 10);
-        let side_pot = side_pot.side_pot.unwrap();
-        assert_eq!(side_pot.players_in.len(), 1);
-        assert_eq!(*side_pot.max_in, 30);
+        dbg!(&p);
+        assert_eq!(p.settled.len(), 3);
+
+        let pot = &p.settled[0];
+        assert_eq!(pot.players.len(), 3);
+        assert_eq!(pot.max_in, Some(5.into()));
+        let pot = &p.settled[1];
+        assert_eq!(pot.players.len(), 2);
+        assert_eq!(pot.max_in, Some(10.into()));
+        let pot = &p.settled[2];
+        assert_eq!(pot.players.len(), 1);
+        assert_eq!(pot.max_in, Some(30.into()));
 
         let mut p = Pot::default();
         p.bet(1, BetAction::AllIn(45.into()));
@@ -475,17 +599,17 @@ mod tests {
         p.bet(3, BetAction::AllIn(5.into()));
         p.finalize_round();
         dbg!(&p);
-        assert_eq!(p.players_in.len(), 3);
-        assert_eq!(*p.max_in, 5);
-        let side_pot = p.side_pot.unwrap();
-        assert_eq!(side_pot.players_in.len(), 2);
-        assert_eq!(*side_pot.max_in, 10);
-        let side_pot = side_pot.side_pot.unwrap();
-        assert_eq!(side_pot.players_in.len(), 1);
-        assert_eq!(*side_pot.max_in, 20);
-        let side_pot = side_pot.side_pot.unwrap();
-        assert_eq!(side_pot.players_in.len(), 1);
-        assert_eq!(*side_pot.max_in, 10);
+        assert_eq!(p.settled.len(), 3);
+
+        let pot = &p.settled[0];
+        assert_eq!(pot.players.len(), 3);
+        assert_eq!(pot.max_in, Some(5.into()));
+        let pot = &p.settled[1];
+        assert_eq!(pot.players.len(), 2);
+        assert_eq!(pot.max_in, Some(10.into()));
+        let pot = &p.settled[2];
+        assert_eq!(pot.players.len(), 1);
+        assert_eq!(pot.max_in, Some(30.into()));
     }
 }
 

--- a/poker-core/src/game/table.rs
+++ b/poker-core/src/game/table.rs
@@ -211,38 +211,38 @@ impl GameInProgress {
 mod tests {
     use super::*;
 
-    #[test]
-    #[ignore = "Not yet finished"]
-    fn basic_game() {
-        let mut gt = GameInProgress::default();
-        gt.sit_down(0, 100, 0).unwrap();
-        gt.sit_down(1, 100, 1).unwrap();
-        gt.sit_down(2, 100, 2).unwrap();
-        gt.sit_down(3, 100, 3).unwrap();
-        gt.start_round().unwrap();
-        // Blinds are in
-        assert_eq!(gt.get_player_info(0).unwrap().monies(), 100.into());
-        assert_eq!(gt.get_player_info(1).unwrap().monies(), 95.into());
-        assert_eq!(gt.get_player_info(2).unwrap().monies(), 90.into());
-        assert_eq!(gt.pot.total_value(), 15.into());
+    // #[test]
+    // #[ignore = "Not yet finished"]
+    // fn basic_game() {
+    //     let mut gt = GameInProgress::default();
+    //     gt.sit_down(0, 100, 0).unwrap();
+    //     gt.sit_down(1, 100, 1).unwrap();
+    //     gt.sit_down(2, 100, 2).unwrap();
+    //     gt.sit_down(3, 100, 3).unwrap();
+    //     gt.start_round().unwrap();
+    //     // Blinds are in
+    //     assert_eq!(gt.get_player_info(0).unwrap().monies(), 100.into());
+    //     assert_eq!(gt.get_player_info(1).unwrap().monies(), 95.into());
+    //     assert_eq!(gt.get_player_info(2).unwrap().monies(), 90.into());
+    //     assert_eq!(gt.pot.total_value(), 15.into());
 
-        gt.bet(3, BetAction::Call(10.into())).unwrap();
-        gt.bet(0, BetAction::Fold).unwrap();
-        // TODO decide if invald Check's should fail or be converted to calls
-        let _r = gt.bet(1, BetAction::Check).unwrap();
-        gt.bet(2, BetAction::Check).unwrap();
+    //     gt.bet(3, BetAction::Call(10.into())).unwrap();
+    //     gt.bet(0, BetAction::Fold).unwrap();
+    //     // TODO decide if invald Check's should fail or be converted to calls
+    //     let _r = gt.bet(1, BetAction::Check).unwrap();
+    //     gt.bet(2, BetAction::Check).unwrap();
 
-        // First betting round is over.
-        // Table should recognize that all players are in and pot is right and forward the round
-        assert_eq!(gt.get_player_info(0).unwrap().monies(), 100.into());
-        assert_eq!(gt.get_player_info(1).unwrap().monies(), 90.into());
-        assert_eq!(gt.get_player_info(2).unwrap().monies(), 90.into());
-        assert_eq!(gt.get_player_info(3).unwrap().monies(), 90.into());
-        assert_eq!(gt.pot.total_value(), 30.into());
-        assert!(gt.table_cards[2].is_some());
+    //     // First betting round is over.
+    //     // Table should recognize that all players are in and pot is right and forward the round
+    //     assert_eq!(gt.get_player_info(0).unwrap().monies(), 100.into());
+    //     assert_eq!(gt.get_player_info(1).unwrap().monies(), 90.into());
+    //     assert_eq!(gt.get_player_info(2).unwrap().monies(), 90.into());
+    //     assert_eq!(gt.get_player_info(3).unwrap().monies(), 90.into());
+    //     assert_eq!(gt.pot.total_value(), 30.into());
+    //     assert!(gt.table_cards[2].is_some());
 
-        // TODO rest of the test once the above passes
-    }
+    //     // TODO rest of the test once the above passes
+    // }
 
     // TODO test where players who are folded try to bet again
 


### PR DESCRIPTION
I thought about this long and hard and think I finally got it done in an elegant enough way.

The key fix is keeping track of whether a bet is all in or not, where before this wasn't done during overflowing.

As part of this, the internals of Pot have been re-imagined while keeping the same interface:

- working is a simple hash map of the players in the current betting round. Instead of trying to constantly keep the inner pots up to date with what funds are able to be won by each player, just collect the players and their bets here until finalize_round() is called.
- settled is a vec of inner pots. The order of settled pots is not important as they will all be visited during payout.
- finalize_round actually does a fair bit of work. It has to turn the working bets into one or more pots, and it puts those into the list of settled pots. It works by sorting the working bets s.t. all ins are before non-all ins, and the smallest all in is first. This is analogous as to how you'd figure out complex side pot situations in real life.

The beautiful recursion of InnerPots is gone. Sorry :(

Additional changes:

- Stake. This is how whether a bet is all in for the player is tracked. Its important use is in finalize_round() for sorting and for setting a pot's max_in when it is created.