### PR TITLE
GameInProgress logging changes

### DIFF
--- a/docs/game-log-plans.md
+++ b/docs/game-log-plans.md
@@ -62,7 +62,7 @@ be leaked outside of poker-core willy-nilly.
 GameInProgress shall be changed (back) to storing logs as they are generated.
 For simplicity's sake, its `pub fn`s such as `bet()` will *not* return logs
 that are generated as a result of the call; instead it is the caller's
-responsibility to call the `logs_since()` function (discussed momentarily)
+responsibility to call the `latest_logs()` function (discussed momentarily)
 immediately after the call if they want any fresh logs.
 
 In support of [issue 42][], GameInProgress will store a small number of full
@@ -81,13 +81,10 @@ The `PocketsDealt(_)` log item with the pocket map will be replaced with a
 one of these will be logged for each player that receives cards. These are the
 log items that never touch the database.
 
-GameInProgress will gain a `pub fn logs_since(usize, PlayerId) ->
-(Vec<LogItem>, usize)`. The usize argument is the index of the most recent log
-the caller knows about. The PlayerId argument is the player that the logs
-should be tailored for, i.e. all `PocketsDealt(_)` for other players will not
-be returned.  The vec return value is the logs, and the usize return value is
-the index of the last live log item (last live log item known about, whether or
-not it is part of the returned vec. AKA it's `live_logs.len()-1`).
+GameInProgress will gain a `pub fn latest_logs() -> Iterator<LogItem>`.  This
+function returns the latest "live" logs since the last time it was called. This
+includes all sensitive per-player logs. The caller must handle these
+responsibly.
 
 An optional feature as part of implementing this document: GameInProgress will
 gain a `pub fn reveal(PlayerId)` to be called when a player voluntarily reveals

--- a/docs/game-log-plans.md
+++ b/docs/game-log-plans.md
@@ -85,9 +85,12 @@ GameInProgress will keep the pocket map in memory for the duration of the
 current hand.
 
 GameInProgress will gain a `pub fn logs_since(usize, PlayerId) ->
-Vec<LogItem>`. The usize is the sequence number of the most recent log the
-caller knows about. The PlayerId is the player that the logs should be tailored
-for, i.e. all `PocketsDealt(_)` for other players will not be returned.
+(Vec<LogItem>, usize)`. The usize argument is the index of the most recent log
+the caller knows about. The PlayerId argument is the player that the logs
+should be tailored for, i.e. all `PocketsDealt(_)` for other players will not
+be returned.  The vec return value is the logs, and the usize return value is
+the index of the last live log item (last live log item known about, whether or
+not it is part of the returned vec. AKA it's `live_logs.len()-1`).
 
 An optional feature as part of implementing this document: GameInProgress will
 gain a `pub fn reveal(PlayerId)` to be called when a player voluntarily reveals

--- a/docs/game-log-plans.md
+++ b/docs/game-log-plans.md
@@ -81,9 +81,6 @@ The `PocketsDealt(_)` log item with the pocket map will be replaced with a
 one of these will be logged for each player that receives cards. These are the
 log items that never touch the database.
 
-GameInProgress will keep the pocket map in memory for the duration of the
-current hand.
-
 GameInProgress will gain a `pub fn logs_since(usize, PlayerId) ->
 (Vec<LogItem>, usize)`. The usize argument is the index of the most recent log
 the caller knows about. The PlayerId argument is the player that the logs

--- a/poker-core/src/game/log.rs
+++ b/poker-core/src/game/log.rs
@@ -2,14 +2,12 @@ use super::deck::Card;
 use super::pot;
 use super::table::GameState;
 use super::{Currency, PlayerId};
-use itertools::Itertools;
-use std::collections::HashMap;
 
 #[derive(Debug)]
 pub enum LogItem {
     Pot(pot::LogItem),
     StateChange(GameState),
-    PocketsDealt(HashMap<PlayerId, Option<[Card; 2]>>),
+    PocketDealt(PlayerId, [Card; 2]),
     SitDown(PlayerId, usize, Currency),
     StandUp(PlayerId, Currency),
     CurrentBetSet(Currency, Currency),
@@ -29,22 +27,8 @@ impl std::fmt::Display for LogItem {
         match self {
             LogItem::Pot(pli) => write!(f, "{pli}"),
             LogItem::StateChange(to) => write!(f, "State changed to {to}"),
-            LogItem::PocketsDealt(map) => {
-                let middle: String = map
-                    .iter()
-                    .map(|(player, p)| {
-                        format!(
-                            "p{}: {}",
-                            player,
-                            match p {
-                                None => "????".to_string(),
-                                Some(p) => format!("{}{}", p[0], p[1]),
-                            }
-                        )
-                    })
-                    .join(", ");
-                let s = "[".to_string() + &middle + "]";
-                write!(f, "Pockets dealt: {}", s)
+            LogItem::PocketDealt(player, pocket) => {
+                write!(f, "p{player} dealt {}{}", pocket[0], pocket[1])
             }
             LogItem::SitDown(p, seat, monies) => {
                 write!(f, "p{} sits in seat {} with {}", p, seat, monies)

--- a/poker-core/src/game/log.rs
+++ b/poker-core/src/game/log.rs
@@ -3,7 +3,7 @@ use super::pot;
 use super::table::GameState;
 use super::{Currency, PlayerId};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum LogItem {
     Pot(pot::LogItem),
     StateChange(GameState),

--- a/poker-core/src/game/table.rs
+++ b/poker-core/src/game/table.rs
@@ -161,13 +161,12 @@ impl GameInProgress {
         // Deal the pockets
         let nump = self.seated_players.betting_players_count() as u8;
         let pockets = self.deck.deal_pockets(nump)?;
-        logs.push(LogItem::PocketsDealt(
+        logs.extend(
             self.seated_players
                 .deal_pockets(pockets)
                 .into_iter()
-                .map(|(k, v)| (k, Some(v)))
-                .collect(),
-        ));
+                .map(|(k, v)| LogItem::PocketDealt(k, v)),
+        );
 
         logs.push(LogItem::CurrentBetSet(self.current_bet, self.min_raise));
         Ok(logs)

--- a/tests/manual-game/Makefile
+++ b/tests/manual-game/Makefile
@@ -5,7 +5,7 @@ TESTS=$(shell find . -mindepth 1 -type d)
 all: $(TESTS)
 
 rebuild:
-	cargo build --release --bin manual-game
+	cargo build --bin manual-game
 
 $(TESTS): rebuild
 	@cd $@ && \


### PR DESCRIPTION
See the new document for a summary of these changes or see #45 or just read below because why not I'll say it again.

- Don't return game logs as they are generated, but hold on to them.
- Replace PocketsDealt with PocketDealt and expect caller to censor.
- Impl live/archive logs as recommended.

Closes #41 

Closes #45 

See #42 

